### PR TITLE
Fix posts pagination display

### DIFF
--- a/assets/css/pagination.css
+++ b/assets/css/pagination.css
@@ -1,0 +1,16 @@
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  list-style: none;
+  padding-left: 0;
+}
+
+.pagination li,
+.pagination li a {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  min-width: 3.2rem;
+}

--- a/config.toml
+++ b/config.toml
@@ -7,6 +7,8 @@ contentDir = "content"
 pluralizelisttitles = false
 googleAnalytics = "G-2NZGH53V36"
 
+paginate = 30
+
 [pagination]
     pagerSize = 30
 
@@ -26,6 +28,7 @@ googleAnalytics = "G-2NZGH53V36"
     favicon_16 = "/images/favicon-16x16.png"
     favicon_32 = "/images/favicon-32x32.png"
     touchIcon = "/images/apple-touch-icon.png"
+    customCSS = ["css/pagination.css"]
 
 [taxonomies]
     category = "categories"


### PR DESCRIPTION
Fixes the posts index pagination behavior across the two Hugo versions currently in play.

Production builds with Hugo 0.111, which still reads the legacy `paginate` key. Local preview uses newer Hugo, which reads `[pagination].pagerSize`. Keeping both at 30 makes the posts page consistent across deploy and preview.

Also adds a small site-owned CSS override so the pagination controls render with stable spacing instead of relying on the theme's inline list-item defaults.

Validation:
- Built with Hugo 0.111.3, matching the GitHub Pages workflow version
- Confirmed generated `public/posts/index.html` includes the custom pagination stylesheet and uses the 30-item page size
- Rebuilt local preview and verified `/posts/` shows 30 post links with spaced pagination controls
