### PR TITLE
Harden posts pagination styling

### DIFF
--- a/assets/css/pagination.css
+++ b/assets/css/pagination.css
@@ -1,10 +1,14 @@
 .pagination {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.8rem;
   justify-content: center;
   list-style: none;
   padding-left: 0;
+}
+
+.pagination .hidden {
+  display: none;
 }
 
 .pagination li,


### PR DESCRIPTION
Tightens the posts paginator so the theme's hidden single-step controls do not leak into the rendered pagination UI after leaving page 1.

This keeps the 30-post page size intact while making page 1, page 2, desktop, and mobile pagination render consistently.

Validation:
- Built locally with Hugo 0.111.3, matching the GitHub Pages workflow.
- Tested deployed behavior with agent-browser to confirm the live failure mode.
- Tested local fixed flow with agent-browser on desktop and mobile, including page 1 -> page 2 and page 2 -> page 1 navigation.